### PR TITLE
ci: Set up Dependabot with auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Keep the GitHub Actions used by the release workflow up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Keep the nginx base image in the Dockerfile up to date.
+  # NOTE: Dependabot can only bump a versioned tag. A floating tag such as
+  # "nginx:alpine" has no version to compare, so pin it (e.g. "nginx:1.27-alpine"
+  # or a digest) for Dependabot to open update PRs.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: Dependabot auto-merge
+
+# Automatically approve and merge every Dependabot pull request — including
+# major version bumps. Requires two repository settings to be enabled:
+#   1. Settings → General → Pull Requests → "Allow auto-merge"
+#   2. Settings → Actions → General → Workflow permissions →
+#      "Allow GitHub Actions to create and approve pull requests"
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve the pull request
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (all updates, including majors)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,8 @@
 name: Dependabot auto-merge
 
-# Automatically approve and merge every Dependabot pull request — including
-# major version bumps. Requires two repository settings to be enabled:
+# Automatically approve and merge Dependabot pull requests for patch and
+# minor updates. Major version bumps are left open for manual review.
+# Requires two repository settings to be enabled:
 #   1. Settings → General → Pull Requests → "Allow auto-merge"
 #   2. Settings → Actions → General → Workflow permissions →
 #      "Allow GitHub Actions to create and approve pull requests"
@@ -24,12 +25,14 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Approve the pull request
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge (all updates, including majors)
+      - name: Enable auto-merge (patch and minor updates only)
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Adds automated dependency updates, based on the Vault project's setup.

## What's added
- **`.github/dependabot.yml`** — weekly update checks for:
  - `github-actions` (keeps the release workflow's actions current)
  - `docker` (the nginx base image)
  - Updates are grouped per ecosystem and labeled `dependencies`.
- **`.github/workflows/dependabot-auto-merge.yml`** — auto-approves and enables squash auto-merge for Dependabot PRs.

## Auto-merge policy
- **Patch + minor** updates → auto-approved and merged.
- **Major** updates → left open for manual review (not auto-merged).

## Required repo settings (one-time)
Auto-merge only works once these are enabled:
- Settings → General → Pull Requests → **Allow auto-merge**
- Settings → Actions → General → Workflow permissions → **Allow GitHub Actions to create and approve pull requests**

## Note
- The Dockerfile uses the floating tag `nginx:alpine`. Dependabot can only bump a *pinned* tag, so the docker ecosystem stays idle until it's pinned (e.g. `nginx:1.27-alpine`).
- Python deps (`api/requirements.txt`) are not tracked here, and are unpinned anyway, so there's nothing for Dependabot to bump yet.