### PR TITLE
chore: Pin Python dependencies and track them with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,18 @@ updates:
         patterns:
           - "*"
 
+  # Keep the Python dependencies (api/requirements.txt) up to date.
+  - package-ecosystem: "pip"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      pip:
+        patterns:
+          - "*"
+
   # Keep the nginx base image in the Dockerfile up to date.
   # NOTE: Dependabot can only bump a versioned tag. A floating tag such as
   # "nginx:alpine" has no version to compare, so pin it (e.g. "nginx:1.27-alpine"

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,8 +1,8 @@
-fastapi
-uvicorn[standard]
-pydantic
-aiosqlite
-python-multipart
-pyotp
-qrcode[pil]
-bcrypt
+fastapi==0.137.1
+uvicorn[standard]==0.49.0
+pydantic==2.13.4
+aiosqlite==0.22.1
+python-multipart==0.0.32
+pyotp==2.10.0
+qrcode[pil]==8.2
+bcrypt==5.0.0


### PR DESCRIPTION
Pins the Python dependencies so Dependabot can actually update them.

## Why
Unpinned requirements (`fastapi`, `uvicorn`, …) give Dependabot no version to compare against, so it never opens PRs. Pinning fixes that and also makes builds reproducible.

## What changed
- **`api/requirements.txt`** — pinned to the versions currently running in the container (latest-at-build, known-good):

  | Package | Version |
  |---|---|
  | fastapi | 0.137.1 |
  | uvicorn[standard] | 0.49.0 |
  | pydantic | 2.13.4 |
  | aiosqlite | 0.22.1 |
  | python-multipart | 0.0.32 |
  | pyotp | 2.10.0 |
  | qrcode[pil] | 8.2 |
  | bcrypt | 5.0.0 |

- **`.github/dependabot.yml`** — added a `pip` ecosystem (directory `/api`), weekly + grouped, matching the existing ecosystems.

## Notes
- These are the exact versions already installed, so a rebuild installs an identical set — no behaviour change.
- After merge, Dependabot will open update PRs for any of these with newer releases. Patch/minor auto-merge; majors wait for review.